### PR TITLE
Install the Gateway API CRDs

### DIFF
--- a/kubernetes/infra/gateway-api.yaml
+++ b/kubernetes/infra/gateway-api.yaml
@@ -1,0 +1,38 @@
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: gateway-api
+  namespace: flux-system
+spec:
+  wait: true
+  inputs:
+    - channel: experimental # or standard
+      version: 1.x # auto upgrade to latest minor
+      interval: 24h # check for updates daily
+  resources:
+    - apiVersion: source.toolkit.fluxcd.io/v1
+      kind: GitRepository
+      metadata:
+        name: << inputs.provider.name >>
+        namespace: << inputs.provider.namespace >>
+      spec:
+        interval: << inputs.interval | quote >>
+        url: https://github.com/kubernetes-sigs/gateway-api.git
+        ref:
+          semver: << inputs.version | quote >>
+    - apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: << inputs.provider.name >>
+        namespace: << inputs.provider.namespace >>
+      spec:
+        serviceAccountName: flux-operator
+        interval: << inputs.interval | quote >>
+        retryInterval: 5m
+        timeout: 3m
+        prune: true
+        wait: true
+        sourceRef:
+          kind: GitRepository
+          name: << inputs.provider.name >>
+        path: config/crd/<< inputs.channel >>


### PR DESCRIPTION
This pull request introduces a new `ResourceSet` configuration for managing the Gateway API in the Kubernetes infrastructure. 

Infrastructure automation:

* Added `kubernetes/infra/gateway-api.yaml` file that defines a `ResourceSet` for installing the Gateway API CRDs, enabling automated and periodic updates via Flux Operator.
* Configured dynamic inputs for deployment channel (`experimental` or `standard`), version (`1.x`), and update interval (`24h`) to support auto-upgrades.

Flux resource definitions:

* Included a `GitRepository` resource to fetch Gateway API manifests from the upstream GitHub repository, using semantic versioning and the specified interval.
* Added a `Kustomization` resource to apply the Gateway API CRDs, with options for pruning, waiting, retries, and timeouts.